### PR TITLE
(deps: dependency) log4j2, redis 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,28 +12,33 @@ repositories {
 	mavenCentral()
 }
 
-/**
- * 아직 의존성은 하나도 추가하지 않음.
- * spring web과 같은 의존성이 먼저 추가되어야 함.
- * jpa는 스프링부트 3.0 특성상 나중에 추가해주는 것이 빌드에 좋을듯.
- */
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf:3.0.4'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa:3.0.4'
-  
-  runtimeOnly 'org.postgresql:postgresql'
+
+	runtimeOnly 'org.postgresql:postgresql'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
 	implementation 'org.postgresql:postgresql:42.5.4'
-  
+
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
+	implementation 'org.springframework.boot:spring-boot-starter-log4j2'
+
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.0.4'
+
+}
+
+configurations{
+	all{
+		exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+	}
 }
 
 tasks.named('test') {


### PR DESCRIPTION
### log4j2와 redis 의존성을 추가하였습니다.

---

### spring-boot-starter-web에는 기본적으로 logback 로깅 모듈이 포함되어 있지만, 성능 상 log4j2가 logback 보다 우수하다고 합니다. 
 log4j2 의존성을 추가해주고 아래 코드처럼 spring-boot-starter-logging을 제외시켜 주었습니다.
```
configurations{
	all{
		exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
	}
}
``` 