### PR TITLE
fix: dockerfile의 build path 이름 수정 및 env 파일을 container 디렉토리에 복사

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,11 @@ RUN mkdir /app
 WORKDIR /app
 
 # (생략 가능) jar 파일 경로가 길어서 변수로 선언
-ARG JAR_FILE=./build/libs/airservice-0.0.1-SNAPSHOT.jar
+ARG JAR_FILE=./build/libs/backend-airservice-0.0.1-SNAPSHOT.jar
 
 # 컨테이너에 jar 파일 복사 및 이름 변경
 COPY ${JAR_FILE} /app/airservice.jar
+COPY ./env.json /app/env.json
 
 EXPOSE 8080
 


### PR DESCRIPTION
1. 프로젝트명이 변경 됨에 따라 build path가 변경 되어, dockerfile의 build path 이름 수정
2. env 파일이 추가됨에 따라 container 환경에서 환경변수를 사용하기 위해 해당 파일 copy