### PR TITLE
(fix: airForecastService) 테스트코드 & 예외처리 & 공통 response

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ def DB_URL = env.DB_URL
 def DB_USERNAME = env.DB_USERNAME
 def DB_PASSWORD = env.DB_PASSWORD
 def DB_NAME = env.DB_NAME
+def AIR_FORECAST_SERVICE_KEY_DE=env.AIR_FORECAST_SERVICE_KEY_DE;
+def KAKAO_REST_API_KEY=env.KAKAO_REST_API_KEY;
 
 // application plugin에서 사용하는 설정
 run {
@@ -70,15 +72,13 @@ tasks.named('test') {
 	systemProperty 'DB_URL', DB_URL
 	systemProperty 'DB_USERNAME', DB_USERNAME
 	systemProperty 'DB_PASSWORD', DB_PASSWORD
+	systemProperty "AIR_FORECAST_SERVICE_KEY_DE", AIR_FORECAST_SERVICE_KEY_DE
+	systemProperty "KAKAO_REST_API_KEY", KAKAO_REST_API_KEY
 }
 
 configurations{
 	all{
 		exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
 	}
-}
-
-tasks.named('test') {
-	useJUnitPlatform()
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ def DB_PASSWORD = env.DB_PASSWORD
 def DB_NAME = env.DB_NAME
 def AIR_FORECAST_SERVICE_KEY_DE=env.AIR_FORECAST_SERVICE_KEY_DE;
 def KAKAO_REST_API_KEY=env.KAKAO_REST_API_KEY;
+def STATION_SERVICE_KE_DE=env.STATION_SERVICE_KE_DE;
 
 // application plugin에서 사용하는 설정
 run {
@@ -74,6 +75,7 @@ tasks.named('test') {
 	systemProperty 'DB_PASSWORD', DB_PASSWORD
 	systemProperty "AIR_FORECAST_SERVICE_KEY_DE", AIR_FORECAST_SERVICE_KEY_DE
 	systemProperty "KAKAO_REST_API_KEY", KAKAO_REST_API_KEY
+	systemProperty "STATION_SERVICE_KE_DE", STATION_SERVICE_KE_DE
 }
 
 configurations{

--- a/src/main/java/com/weatherwhere/airservice/controller/airforecast/AirForecastController.java
+++ b/src/main/java/com/weatherwhere/airservice/controller/airforecast/AirForecastController.java
@@ -18,7 +18,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
-@RequestMapping("air/forecast")
+@RequestMapping("/air/forecast")
 @Slf4j
 @RequiredArgsConstructor
 public class AirForecastController {

--- a/src/main/java/com/weatherwhere/airservice/controller/airforecast/AirForecastController.java
+++ b/src/main/java/com/weatherwhere/airservice/controller/airforecast/AirForecastController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.weatherwhere.airservice.dto.airforecast.SearchAirForecastDto;
-import com.weatherwhere.airservice.dto.response.ResultDto;
+import com.weatherwhere.airservice.dto.ResultDto;
 import com.weatherwhere.airservice.service.airforecast.AirForecastApiService;
 import com.weatherwhere.airservice.service.airforecast.GetAirForecastDataService;
 

--- a/src/main/java/com/weatherwhere/airservice/controller/airforecast/AirForecastController.java
+++ b/src/main/java/com/weatherwhere/airservice/controller/airforecast/AirForecastController.java
@@ -1,7 +1,7 @@
 package com.weatherwhere.airservice.controller.airforecast;
 
 import java.time.LocalDate;
-import java.util.List;
+
 import org.json.simple.parser.ParseException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -9,8 +9,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.weatherwhere.airservice.dto.airforecast.AirForecastDto;
 import com.weatherwhere.airservice.dto.airforecast.SearchAirForecastDto;
+import com.weatherwhere.airservice.dto.response.ResultDto;
 import com.weatherwhere.airservice.service.airforecast.AirForecastApiService;
 import com.weatherwhere.airservice.service.airforecast.GetAirForecastDataService;
 
@@ -27,14 +27,14 @@ public class AirForecastController {
     private final GetAirForecastDataService getAirForecastDataService;
     // 공공데이터 api 호출해서 db에 저장
     @GetMapping(value = "/api")
-    public List<AirForecastDto> getAirForecastApiData(@RequestParam LocalDate date) throws
+    public ResultDto<Object> getAirForecastApiData(@RequestParam LocalDate date) throws
         ParseException, java.text.ParseException {
         return airForecastService.getApiData(date);
     }
 
     // 7일의 대기 주간예보 데이터 가져오기!
     @GetMapping(value = "/data")
-    public List<AirForecastDto> getSevenDaysAirForecastData(@ModelAttribute SearchAirForecastDto searchAirForecastDto) throws
+    public ResultDto<Object> getSevenDaysAirForecastData(@ModelAttribute SearchAirForecastDto searchAirForecastDto) throws
         Exception {
         return getAirForecastDataService.getSevenDaysDataOfLocation(searchAirForecastDto);
     }

--- a/src/main/java/com/weatherwhere/airservice/controller/airforecast/AirForecastController.java
+++ b/src/main/java/com/weatherwhere/airservice/controller/airforecast/AirForecastController.java
@@ -11,8 +11,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.weatherwhere.airservice.dto.airforecast.AirForecastDto;
 import com.weatherwhere.airservice.dto.airforecast.SearchAirForecastDto;
-import com.weatherwhere.airservice.service.airforecast.AirForecastApiServiceImpl;
-import com.weatherwhere.airservice.service.airforecast.GetAirForecastDataServiceImpl;
+import com.weatherwhere.airservice.service.airforecast.AirForecastApiService;
+import com.weatherwhere.airservice.service.airforecast.GetAirForecastDataService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,9 +22,9 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RequiredArgsConstructor
 public class AirForecastController {
-    private final AirForecastApiServiceImpl airForecastService;
+    private final AirForecastApiService airForecastService;
 
-    private final GetAirForecastDataServiceImpl getAirForecastDataService;
+    private final GetAirForecastDataService getAirForecastDataService;
     // 공공데이터 api 호출해서 db에 저장
     @GetMapping(value = "/api")
     public List<AirForecastDto> getAirForecastApiData(@RequestParam LocalDate date) throws

--- a/src/main/java/com/weatherwhere/airservice/dto/ResultDto.java
+++ b/src/main/java/com/weatherwhere/airservice/dto/ResultDto.java
@@ -1,4 +1,4 @@
-package com.weatherwhere.airservice.dto.response;
+package com.weatherwhere.airservice.dto;
 
 import lombok.Data;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/weatherwhere/airservice/dto/response/ResultDto.java
+++ b/src/main/java/com/weatherwhere/airservice/dto/response/ResultDto.java
@@ -1,0 +1,12 @@
+package com.weatherwhere.airservice.dto.response;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@RequiredArgsConstructor(staticName = "of")
+public class ResultDto<T> {
+    private final int resultCode;
+    private final String message;
+    private final T data;
+}

--- a/src/main/java/com/weatherwhere/airservice/service/airforecast/AirForecastApiService.java
+++ b/src/main/java/com/weatherwhere/airservice/service/airforecast/AirForecastApiService.java
@@ -1,16 +1,17 @@
 package com.weatherwhere.airservice.service.airforecast;
 
 import java.time.LocalDate;
-import java.util.List;
 
 import org.json.simple.parser.ParseException;
+
 import com.weatherwhere.airservice.domain.airforecast.AirForecastEntity;
 import com.weatherwhere.airservice.domain.airforecast.AirForecastId;
 import com.weatherwhere.airservice.dto.airforecast.AirForecastDto;
+import com.weatherwhere.airservice.dto.response.ResultDto;
 
 public interface AirForecastApiService {
     // 대기 주간예보 api 데이터 받아오는 메서드
-    List<AirForecastDto> getApiData(LocalDate date) throws ParseException, java.text.ParseException;
+    ResultDto<Object> getApiData(LocalDate date) throws ParseException, java.text.ParseException;
 
     // DTO -> Entity
     default AirForecastEntity toEntity(AirForecastDto dto){

--- a/src/main/java/com/weatherwhere/airservice/service/airforecast/AirForecastApiService.java
+++ b/src/main/java/com/weatherwhere/airservice/service/airforecast/AirForecastApiService.java
@@ -7,7 +7,7 @@ import org.json.simple.parser.ParseException;
 import com.weatherwhere.airservice.domain.airforecast.AirForecastEntity;
 import com.weatherwhere.airservice.domain.airforecast.AirForecastId;
 import com.weatherwhere.airservice.dto.airforecast.AirForecastDto;
-import com.weatherwhere.airservice.dto.response.ResultDto;
+import com.weatherwhere.airservice.dto.ResultDto;
 
 public interface AirForecastApiService {
     // 대기 주간예보 api 데이터 받아오는 메서드

--- a/src/main/java/com/weatherwhere/airservice/service/airforecast/AirForecastApiServiceImpl.java
+++ b/src/main/java/com/weatherwhere/airservice/service/airforecast/AirForecastApiServiceImpl.java
@@ -86,17 +86,12 @@ public class AirForecastApiServiceImpl implements AirForecastApiService {
     public List<AirForecastDto> saveDb(List<AirForecastDto> dtoList){
         List<AirForecastDto> resultDtoList=new ArrayList<>();
 
-        try{
-            for (AirForecastDto dto : dtoList){
-                AirForecastEntity airForecastEntity=toEntity(dto);
-                airForecastRepository.save(airForecastEntity);
-                resultDtoList.add(toDto(airForecastEntity));
-            }
-            log.info("saveDB: {}",resultDtoList);
-        }catch (Exception e){
-            e.printStackTrace();
-            log.error("saveDB error: {}",e.getMessage());
+        for (AirForecastDto dto : dtoList){
+            AirForecastEntity airForecastEntity=toEntity(dto);
+            airForecastRepository.save(airForecastEntity);
+            resultDtoList.add(toDto(airForecastEntity));
         }
+        log.info("saveDB: {}",resultDtoList);
 
         return resultDtoList;
     }
@@ -121,9 +116,17 @@ public class AirForecastApiServiceImpl implements AirForecastApiService {
                 dtoList.addAll(saveDb(dataList));
             }
             log.info("대기 주간예보 호출 데이터:{}",data);
-        }catch (Exception e){
+        }catch (IndexOutOfBoundsException e){
+            // 공공데이터 api에 없는 정보 호출했을 경우
             e.printStackTrace();
             log.error("getApiData error:{}",e.getMessage());
+        }catch (ParseException | java.text.ParseException e){
+            // json 데이터 파싱할 때 error
+            e.printStackTrace();
+            log.error("data parsing error: {}",e.getMessage());
+        }catch (Exception e){
+            e.printStackTrace();
+            log.error("error: {}",e.getMessage());
         }
 
         return dtoList;

--- a/src/main/java/com/weatherwhere/airservice/service/airforecast/AirForecastApiServiceImpl.java
+++ b/src/main/java/com/weatherwhere/airservice/service/airforecast/AirForecastApiServiceImpl.java
@@ -92,9 +92,10 @@ public class AirForecastApiServiceImpl implements AirForecastApiService {
                 airForecastRepository.save(airForecastEntity);
                 resultDtoList.add(toDto(airForecastEntity));
             }
+            log.info("saveDB: {}",resultDtoList);
         }catch (Exception e){
             e.printStackTrace();
-            log.error("saveDB error: "+e.getMessage());
+            log.error("saveDB error: {}",e.getMessage());
         }
 
         return resultDtoList;
@@ -119,10 +120,10 @@ public class AirForecastApiServiceImpl implements AirForecastApiService {
                 List<AirForecastDto> dataList=dataToDto(data.get(key), key);
                 dtoList.addAll(saveDb(dataList));
             }
-            log.info("대기 주간예보 저장 데이터: "+dtoList);
+            log.info("대기 주간예보 호출 데이터:{}",data);
         }catch (Exception e){
             e.printStackTrace();
-            log.error("getApiData error: "+e.getMessage());
+            log.error("getApiData error:{}",e.getMessage());
         }
 
         return dtoList;

--- a/src/main/java/com/weatherwhere/airservice/service/airforecast/AirForecastApiServiceImpl.java
+++ b/src/main/java/com/weatherwhere/airservice/service/airforecast/AirForecastApiServiceImpl.java
@@ -86,18 +86,24 @@ public class AirForecastApiServiceImpl implements AirForecastApiService {
     public List<AirForecastDto> saveDb(List<AirForecastDto> dtoList){
         List<AirForecastDto> resultDtoList=new ArrayList<>();
 
-        for (AirForecastDto dto : dtoList){
-            AirForecastEntity airForecastEntity=toEntity(dto);
-            airForecastRepository.save(airForecastEntity);
-            resultDtoList.add(toDto(airForecastEntity));
+        try{
+            for (AirForecastDto dto : dtoList){
+                AirForecastEntity airForecastEntity=toEntity(dto);
+                airForecastRepository.save(airForecastEntity);
+                resultDtoList.add(toDto(airForecastEntity));
+            }
+        }catch (Exception e){
+            e.printStackTrace();
+            log.error("saveDB error: "+e.getMessage());
         }
+
         return resultDtoList;
     }
 
 
     // 대기 주간예보 api 데이터 받아오기 & db 저장
     @Override
-    public List<AirForecastDto> getApiData(LocalDate date) throws java.text.ParseException, ParseException {
+    public List<AirForecastDto> getApiData(LocalDate date){
         List<AirForecastDto> dtoList=new ArrayList<>();
 
         RestTemplate restTemplate= new RestTemplate();
@@ -108,16 +114,15 @@ public class AirForecastApiServiceImpl implements AirForecastApiService {
             // Json 파싱해서 4일 data 저장
             HashMap<LocalDate,String> data=jsonParsing(result);
 
-
             // 4일 데이터 가공해서 db에 넣기
             for(LocalDate key: data.keySet()){ // key: 날짜, value: 가공 전 데이터
                 List<AirForecastDto> dataList=dataToDto(data.get(key), key);
                 dtoList.addAll(saveDb(dataList));
             }
-
+            log.info("대기 주간예보 저장 데이터: "+dtoList);
         }catch (Exception e){
             e.printStackTrace();
-
+            log.error("getApiData error: "+e.getMessage());
         }
 
         return dtoList;

--- a/src/main/java/com/weatherwhere/airservice/service/airforecast/AirForecastApiServiceImpl.java
+++ b/src/main/java/com/weatherwhere/airservice/service/airforecast/AirForecastApiServiceImpl.java
@@ -82,8 +82,7 @@ public class AirForecastApiServiceImpl implements AirForecastApiService {
     }
 
     // db 저장
-    @Transactional
-    public List<AirForecastDto> saveDb(List<AirForecastDto> dtoList){
+    private List<AirForecastDto> saveDb(List<AirForecastDto> dtoList){
         List<AirForecastDto> resultDtoList=new ArrayList<>();
 
         for (AirForecastDto dto : dtoList){

--- a/src/main/java/com/weatherwhere/airservice/service/airforecast/AirForecastApiServiceImpl.java
+++ b/src/main/java/com/weatherwhere/airservice/service/airforecast/AirForecastApiServiceImpl.java
@@ -17,7 +17,7 @@ import org.springframework.web.client.RestTemplate;
 import com.weatherwhere.airservice.domain.airforecast.AirForecastEntity;
 import com.weatherwhere.airservice.domain.airforecast.AirForecastId;
 import com.weatherwhere.airservice.dto.airforecast.AirForecastDto;
-import com.weatherwhere.airservice.dto.response.ResultDto;
+import com.weatherwhere.airservice.dto.ResultDto;
 import com.weatherwhere.airservice.repository.airforecast.AirForecastRepository;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/weatherwhere/airservice/service/airforecast/GetAirForecastDataService.java
+++ b/src/main/java/com/weatherwhere/airservice/service/airforecast/GetAirForecastDataService.java
@@ -1,17 +1,16 @@
 package com.weatherwhere.airservice.service.airforecast;
 
-import java.util.List;
-
 import com.weatherwhere.airservice.domain.airforecast.AirForecastEntity;
 import com.weatherwhere.airservice.dto.airforecast.AirForecastDto;
 import com.weatherwhere.airservice.dto.airforecast.SearchAirForecastDto;
+import com.weatherwhere.airservice.dto.response.ResultDto;
 
 public interface GetAirForecastDataService {
 
     // 해당 위치 7일 대기오염 주간예보 DB 가져오기
     // startDate에서 필요한 형식은 yyyy-MM-dd
 
-    List<AirForecastDto> getSevenDaysDataOfLocation(SearchAirForecastDto searchAirForecastDto) throws Exception;
+    ResultDto<Object> getSevenDaysDataOfLocation(SearchAirForecastDto searchAirForecastDto) throws Exception;
 
 
     // Entity->DTO

--- a/src/main/java/com/weatherwhere/airservice/service/airforecast/GetAirForecastDataService.java
+++ b/src/main/java/com/weatherwhere/airservice/service/airforecast/GetAirForecastDataService.java
@@ -3,7 +3,7 @@ package com.weatherwhere.airservice.service.airforecast;
 import com.weatherwhere.airservice.domain.airforecast.AirForecastEntity;
 import com.weatherwhere.airservice.dto.airforecast.AirForecastDto;
 import com.weatherwhere.airservice.dto.airforecast.SearchAirForecastDto;
-import com.weatherwhere.airservice.dto.response.ResultDto;
+import com.weatherwhere.airservice.dto.ResultDto;
 
 public interface GetAirForecastDataService {
 

--- a/src/main/java/com/weatherwhere/airservice/service/airforecast/GetAirForecastDataServiceImpl.java
+++ b/src/main/java/com/weatherwhere/airservice/service/airforecast/GetAirForecastDataServiceImpl.java
@@ -14,9 +14,11 @@ import com.weatherwhere.airservice.dto.airforecast.AirForecastDto;
 import com.weatherwhere.airservice.dto.airforecast.SearchAirForecastDto;
 import com.weatherwhere.airservice.repository.airforecast.AirForecastRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 
 @Service
 @RequiredArgsConstructor
+@Log4j2
 public class GetAirForecastDataServiceImpl implements GetAirForecastDataService{
     private final AirForecastRepository airForecastRepository;
 
@@ -30,19 +32,25 @@ public class GetAirForecastDataServiceImpl implements GetAirForecastDataService{
 
 
         List<AirForecastDto> sevenDaysData=new ArrayList<>();
-        for(int i=0; i<7; i++){
-            AirForecastId searchId=new AirForecastId();
-            LocalDate searchDate=airForecastId.getBaseDate().plusDays(i);// 호출한 LocalDate 객체에 일(day)이 더해진 LocalDate 객체를 반환합니다.
-            searchId.setBaseDate(searchDate);
-            searchId.setCity(airForecastId.getCity());
+        try{
+            for(int i=0; i<7; i++){
+                AirForecastId searchId=new AirForecastId();
+                LocalDate searchDate=airForecastId.getBaseDate().plusDays(i);// 호출한 LocalDate 객체에 일(day)이 더해진 LocalDate 객체를 반환합니다.
+                searchId.setBaseDate(searchDate);
+                searchId.setCity(airForecastId.getCity());
 
-
-            // db에서 해당 날짜가 없을 때  예외처리!
-            AirForecastEntity airForecastEntity=airForecastRepository.findByAirForecastId(searchId)
-                .orElseThrow(() -> new NoSuchElementException());
-            sevenDaysData.add(entityToDto(airForecastEntity));
-
+                // db에서 해당 날짜가 없을 때  예외처리!
+                AirForecastEntity airForecastEntity=airForecastRepository.findByAirForecastId(searchId)
+                    .orElseThrow(() -> new NoSuchElementException());
+                sevenDaysData.add(entityToDto(airForecastEntity));
+            }
+        }catch (NoSuchElementException e){
+            e.getStackTrace();
+            log.error("db에 7일의 주간예보 데이터 없음");
         }
+        // 데이터가 DB에 없더라면 7개 안채워진채로 나갈 수 있음!
+        log.info("주간예보 개수: "+sevenDaysData.size());
+        log.info("7일의 주간예보: "+sevenDaysData);
         return sevenDaysData;
     }
 }

--- a/src/main/java/com/weatherwhere/airservice/service/airforecast/GetAirForecastDataServiceImpl.java
+++ b/src/main/java/com/weatherwhere/airservice/service/airforecast/GetAirForecastDataServiceImpl.java
@@ -49,8 +49,8 @@ public class GetAirForecastDataServiceImpl implements GetAirForecastDataService{
             log.error("db에 7일의 주간예보 데이터 없음");
         }
         // 데이터가 DB에 없더라면 7개 안채워진채로 나갈 수 있음!
-        log.info("주간예보 개수: "+sevenDaysData.size());
-        log.info("7일의 주간예보: "+sevenDaysData);
+        log.info("주간예보 개수: {}",sevenDaysData.size());
+        log.info("7일의 주간예보: {}",sevenDaysData);
         return sevenDaysData;
     }
 }

--- a/src/main/java/com/weatherwhere/airservice/service/airforecast/GetAirForecastDataServiceImpl.java
+++ b/src/main/java/com/weatherwhere/airservice/service/airforecast/GetAirForecastDataServiceImpl.java
@@ -34,10 +34,9 @@ public class GetAirForecastDataServiceImpl implements GetAirForecastDataService{
         List<AirForecastDto> sevenDaysData=new ArrayList<>();
         try{
             for(int i=0; i<7; i++){
-                AirForecastId searchId=new AirForecastId();
+
                 LocalDate searchDate=airForecastId.getBaseDate().plusDays(i);// 호출한 LocalDate 객체에 일(day)이 더해진 LocalDate 객체를 반환합니다.
-                searchId.setBaseDate(searchDate);
-                searchId.setCity(airForecastId.getCity());
+                AirForecastId searchId=new AirForecastId(searchDate,airForecastId.getCity());
 
                 // db에서 해당 날짜가 없을 때  예외처리!
                 AirForecastEntity airForecastEntity=airForecastRepository.findByAirForecastId(searchId)

--- a/src/main/java/com/weatherwhere/airservice/service/airforecast/GetAirForecastDataServiceImpl.java
+++ b/src/main/java/com/weatherwhere/airservice/service/airforecast/GetAirForecastDataServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,6 +13,7 @@ import com.weatherwhere.airservice.domain.airforecast.AirForecastEntity;
 import com.weatherwhere.airservice.domain.airforecast.AirForecastId;
 import com.weatherwhere.airservice.dto.airforecast.AirForecastDto;
 import com.weatherwhere.airservice.dto.airforecast.SearchAirForecastDto;
+import com.weatherwhere.airservice.dto.response.ResultDto;
 import com.weatherwhere.airservice.repository.airforecast.AirForecastRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -25,7 +27,7 @@ public class GetAirForecastDataServiceImpl implements GetAirForecastDataService{
     // 해당 위치 7일 대기오염 주간예보 DB 가져오기
     @Override
     @Transactional
-    public List<AirForecastDto> getSevenDaysDataOfLocation(SearchAirForecastDto searchAirForecastDto){
+    public ResultDto<Object> getSevenDaysDataOfLocation(SearchAirForecastDto searchAirForecastDto){
         AirForecastId airForecastId=new AirForecastId();
         airForecastId.setBaseDate(searchAirForecastDto.getBaseDate());
         airForecastId.setCity(searchAirForecastDto.getCity());
@@ -43,16 +45,17 @@ public class GetAirForecastDataServiceImpl implements GetAirForecastDataService{
                     .orElseThrow(() -> new NoSuchElementException());
                 sevenDaysData.add(entityToDto(airForecastEntity));
             }
+            log.info("주간예보 개수: {}",sevenDaysData.size());
+            log.info("7일의 주간예보: {}",sevenDaysData);
+            return ResultDto.of(HttpStatus.OK.value(),"대기 주간예보 7일 데이터를 조회하는데 성공하였습니다.",sevenDaysData);
         }catch (NoSuchElementException e){
             // db에서 찾는 데이터 없을 경우
             e.getStackTrace();
             log.error("db에 7일의 주간예보 데이터 없음");
+            return ResultDto.of(HttpStatus.INTERNAL_SERVER_ERROR.value(), "NoSuchElementException이 발생했습니다.", null);
         }catch (Exception e){
             log.error(e.getMessage());
+            return ResultDto.of(HttpStatus.INTERNAL_SERVER_ERROR.value(), "예기치 못한 에러가 발생했습니다.", null);
         }
-        // 데이터가 DB에 없더라면 7개 안채워진채로 나갈 수 있음!
-        log.info("주간예보 개수: {}",sevenDaysData.size());
-        log.info("7일의 주간예보: {}",sevenDaysData);
-        return sevenDaysData;
     }
 }

--- a/src/main/java/com/weatherwhere/airservice/service/airforecast/GetAirForecastDataServiceImpl.java
+++ b/src/main/java/com/weatherwhere/airservice/service/airforecast/GetAirForecastDataServiceImpl.java
@@ -13,7 +13,7 @@ import com.weatherwhere.airservice.domain.airforecast.AirForecastEntity;
 import com.weatherwhere.airservice.domain.airforecast.AirForecastId;
 import com.weatherwhere.airservice.dto.airforecast.AirForecastDto;
 import com.weatherwhere.airservice.dto.airforecast.SearchAirForecastDto;
-import com.weatherwhere.airservice.dto.response.ResultDto;
+import com.weatherwhere.airservice.dto.ResultDto;
 import com.weatherwhere.airservice.repository.airforecast.AirForecastRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;

--- a/src/main/java/com/weatherwhere/airservice/service/airforecast/GetAirForecastDataServiceImpl.java
+++ b/src/main/java/com/weatherwhere/airservice/service/airforecast/GetAirForecastDataServiceImpl.java
@@ -25,7 +25,7 @@ public class GetAirForecastDataServiceImpl implements GetAirForecastDataService{
     // 해당 위치 7일 대기오염 주간예보 DB 가져오기
     @Override
     @Transactional
-    public List<AirForecastDto> getSevenDaysDataOfLocation(SearchAirForecastDto searchAirForecastDto) throws Exception {
+    public List<AirForecastDto> getSevenDaysDataOfLocation(SearchAirForecastDto searchAirForecastDto){
         AirForecastId airForecastId=new AirForecastId();
         airForecastId.setBaseDate(searchAirForecastDto.getBaseDate());
         airForecastId.setCity(searchAirForecastDto.getCity());
@@ -45,8 +45,11 @@ public class GetAirForecastDataServiceImpl implements GetAirForecastDataService{
                 sevenDaysData.add(entityToDto(airForecastEntity));
             }
         }catch (NoSuchElementException e){
+            // db에서 찾는 데이터 없을 경우
             e.getStackTrace();
             log.error("db에 7일의 주간예보 데이터 없음");
+        }catch (Exception e){
+            log.error(e.getMessage());
         }
         // 데이터가 DB에 없더라면 7개 안채워진채로 나갈 수 있음!
         log.info("주간예보 개수: {}",sevenDaysData.size());

--- a/src/test/java/com/weatherwhere/airservice/airforecast/AitForecastTests.java
+++ b/src/test/java/com/weatherwhere/airservice/airforecast/AitForecastTests.java
@@ -1,0 +1,64 @@
+package com.weatherwhere.airservice.airforecast;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import org.json.simple.parser.ParseException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.weatherwhere.airservice.dto.airforecast.SearchAirForecastDto;
+import com.weatherwhere.airservice.service.airforecast.AirForecastApiService;
+import com.weatherwhere.airservice.service.airforecast.AirForecastApiServiceImpl;
+import com.weatherwhere.airservice.service.airforecast.GetAirForecastDataServiceImpl;
+
+@SpringBootTest
+public class AitForecastTests {
+    @Autowired
+    private AirForecastApiService airForecastApiService;
+
+    @Autowired
+    private GetAirForecastDataServiceImpl getAirForecastDataService;
+
+    static LocalDate date;
+    @BeforeEach
+    void beforeSetUp(){
+        // 오늘 날짜 전날
+        date = LocalDate.now();
+        DateTimeFormatter formatter = DateTimeFormatter.ISO_DATE;
+        String formatted = date.format(formatter);
+        date=date.minusDays(1);
+    }
+
+
+
+    @Test
+    @DisplayName("대기 주간예보 api를 호출하고 db에 저장하는 테스트")
+    public void testGetApi() throws ParseException, java.text.ParseException {
+        /*
+        // 오늘 날짜 전날
+        LocalDate date = LocalDate.now();
+        DateTimeFormatter formatter = DateTimeFormatter.ISO_DATE;
+        String formatted = date.format(formatter);
+        date=date.minusDays(1);
+        System.out.println("date:     "+date);*/
+
+        // 아직 임시로 print하고 나중에 response에 성공여부 출력해보기
+        System.out.println(airForecastApiService.getApiData(date));
+       // Assertions.assertEquals();
+    }
+
+    @Test
+    @DisplayName("7일의 주간예보 DB에서 조회하는 테스트")
+    public void testGetSevenDaysData(){
+        SearchAirForecastDto searchAirForecastDto=new SearchAirForecastDto(date,"서울");
+
+        // 아직 임시로 print하고 나중에 response에 성공여부 출력해보기
+        System.out.println(getAirForecastDataService.getSevenDaysDataOfLocation(searchAirForecastDto));
+        // Assertions.assertEquals();
+    }
+}

--- a/src/test/java/com/weatherwhere/airservice/airforecast/AitForecastTests.java
+++ b/src/test/java/com/weatherwhere/airservice/airforecast/AitForecastTests.java
@@ -4,7 +4,6 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
 import org.json.simple.parser.ParseException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,8 +12,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import com.weatherwhere.airservice.dto.airforecast.SearchAirForecastDto;
 import com.weatherwhere.airservice.service.airforecast.AirForecastApiService;
-import com.weatherwhere.airservice.service.airforecast.AirForecastApiServiceImpl;
-import com.weatherwhere.airservice.service.airforecast.GetAirForecastDataServiceImpl;
+import com.weatherwhere.airservice.service.airforecast.GetAirForecastDataService;
+
 
 @SpringBootTest
 public class AitForecastTests {
@@ -22,7 +21,7 @@ public class AitForecastTests {
     private AirForecastApiService airForecastApiService;
 
     @Autowired
-    private GetAirForecastDataServiceImpl getAirForecastDataService;
+    private GetAirForecastDataService getAirForecastDataService;
 
     static LocalDate date;
     @BeforeEach
@@ -54,7 +53,7 @@ public class AitForecastTests {
 
     @Test
     @DisplayName("7일의 주간예보 DB에서 조회하는 테스트")
-    public void testGetSevenDaysData(){
+    public void testGetSevenDaysData() throws Exception {
         SearchAirForecastDto searchAirForecastDto=new SearchAirForecastDto(date,"서울");
 
         // 아직 임시로 print하고 나중에 response에 성공여부 출력해보기


### PR DESCRIPTION
- [x] 테스트코드
- [x] 예외처리
- [x] 공통 responseDto

---

## 1. 예외처리

### 7일의 주간예보 데이터가 db에 없을 때 예외처리
- 7일이 없더라면 가지고있는 데이터만 출력함! 

---

### 2. 대기 주간예보 테스트코드 작성
- 곧 assertion으로 수정하기 

---

## 3. 공통 responseDto
### 공통 Response DTO를 사용하는 경우, 모든 API 응답에 대해 동일한 필드(예: 응답 코드, 메시지, 데이터 등)를 포함하는 단일 클래스를 정의합니다. 이렇게 하면 코드의 중복을 줄이고, API 응답을 쉽게 유 지 보수하고 업데이트할 수 있습니다.

<img width="371" alt="image" src="https://user-images.githubusercontent.com/40010878/229159681-965fafea-891c-484b-8824-bc34252da5eb.png">

- response 에서 요청된 응답 값만 전달해주는게 아니라 결과에 대한 코드, 메세지, 데이터 포맷으로 전달해줘 프론트에서 더 효율적으로 사용하게 하기 위한 목적
- 공통 responseDto를 만들어 data 타입을 제네릭으로 지정!
- 에러 발생했을 때
![image](https://user-images.githubusercontent.com/40010878/229160645-6fb925e1-3906-4ccc-a4a1-286bcce20bb9.png)

- 성공했을 때
<img width="547" alt="image" src="https://user-images.githubusercontent.com/40010878/229161428-4f73fd85-cb4f-4347-be6b-6ae797e9de0a.png">
