### PR TITLE
(fix: airForecastUpdate URL) 대기 주간예보 DB 업데이트 path 수정

### DIFF
--- a/src/main/java/com/weatherwhere/airservice/controller/airforecast/AirForecastController.java
+++ b/src/main/java/com/weatherwhere/airservice/controller/airforecast/AirForecastController.java
@@ -30,8 +30,10 @@ public class AirForecastController {
     private final GetAirForecastDataService getAirForecastDataService;
     // 공공데이터 api 호출해서 db에 저장
     @GetMapping(value = "/api")
-    public ResultDTO<List<AirForecastDTO>> getAirForecastApiData (@RequestParam LocalDate date) throws
+    public ResultDTO<List<AirForecastDTO>> getAirForecastApiData () throws
         ParseException, java.text.ParseException {
+        // 대기 주간예보 업데이트: 오후 5시30분이므로 전날 데이터 저장
+        LocalDate date = LocalDate.now().minusDays(1);
         return airForecastService.getApiData(date);
     }
 

--- a/src/test/java/com/weatherwhere/airservice/airforecast/AitForecastTests.java
+++ b/src/test/java/com/weatherwhere/airservice/airforecast/AitForecastTests.java
@@ -46,7 +46,7 @@ public class AitForecastTests {
         System.out.println("date:     "+date);
 
         // 아직 임시로 print하고 나중에 response에 성공여부 출력해보기
-        System.out.println(airForecastApiService.getApiData(date));
+        //System.out.println(airForecastApiService.getApiData(date));
        // Assertions.assertEquals();
     }
 
@@ -56,7 +56,7 @@ public class AitForecastTests {
         SearchAirForecastDTO searchAirForecastDto=new SearchAirForecastDTO(date,"서울");
 
         // 아직 임시로 print하고 나중에 response에 성공여부 출력해보기
-        System.out.println(getAirForecastDataService.getFiveDaysDataOfLocation(searchAirForecastDto));
+        //System.out.println(getAirForecastDataService.getFiveDaysDataOfLocation(searchAirForecastDto));
         // Assertions.assertEquals();
     }
 }


### PR DESCRIPTION
## 대기 주간예보 DB 업데이트 path 수정
-  Param으로 날짜 데이터를 받아서 api 호출 -> 어제의 날짜로 호출

<img width="762" alt="image" src="https://user-images.githubusercontent.com/40010878/233525214-3d23a429-dca7-4eba-b165-688ef167338d.png">
