### PR TITLE
(fix:realtimejobcompletion) DB에서 받아오는 값 정상적으로 받아오게 수정

### DIFF
--- a/src/main/java/com/weatherwhere/airservice/config/JobCompletionNotificationListener.java
+++ b/src/main/java/com/weatherwhere/airservice/config/JobCompletionNotificationListener.java
@@ -10,6 +10,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
+
 @Component
 public class JobCompletionNotificationListener implements JobExecutionListener {
     private static final Logger log = LoggerFactory.getLogger(JobCompletionNotificationListener.class);
@@ -29,15 +31,34 @@ public class JobCompletionNotificationListener implements JobExecutionListener {
         startTime = System.currentTimeMillis();
     }
 
+
     @Override
     public void afterJob(JobExecution jobExecution) {
         if (jobExecution.getStatus() == BatchStatus.COMPLETED) {
             log.info("!!! JOB FINISHED! Time to verify the results");
-            jdbcTemplate.query("select measuring_station from air.air_pollution_daily",
-                    (rs, row) -> RealTimeAirEntity.builder().stationName(rs.getString(1)).build()
+            jdbcTemplate.query("select * from air.air_pollution_daily",
+                    (rs, row) -> RealTimeAirEntity.builder()
+                            .stationName(rs.getString("measuring_station"))
+                            .dataTime(rs.getObject("data_time", LocalDateTime.class))
+                            .so2Grade(rs.getInt("so2_grade"))
+                            .khaiValue(rs.getInt("khai_value"))
+                            .so2Value(rs.getDouble("so2_value"))
+                            .coValue(rs.getDouble("co_value"))
+                            .pm10Value(rs.getInt("pm10_value"))
+                            .o3Grade(rs.getInt("o3_grade"))
+                            .khaiGrade(rs.getInt("khai_grade"))
+                            .pm25Value(rs.getInt("pm25_value"))
+                            .no2Grade(rs.getInt("no2_grade"))
+                            .pm25Grade(rs.getInt("pm25_grade"))
+                            .coGrade(rs.getInt("co_grade"))
+                            .no2Value(rs.getDouble("no2_value"))
+                            .pm10Grade(rs.getInt("pm10_grade"))
+                            .o3Value(rs.getDouble("o3_value"))
+                            .build()
             ).forEach(person -> log.info("Found <{{}}> in the database.", person));
             endTime = System.currentTimeMillis();
             System.out.println("Job took " + (endTime - startTime) + "ms");
         }
     }
+
 }


### PR DESCRIPTION
기존에 DB에서 데이터 값을 받아와 로그로 표시해줄때 측성소 명을 제외한 다른 컬럼들의 값이 nulll 과 0이 였는데 그것을 제대로 불러오게 했습니다.